### PR TITLE
multi profile iam data cache

### DIFF
--- a/airiam/find_unused/RuntimeIamScanner.py
+++ b/airiam/find_unused/RuntimeIamScanner.py
@@ -14,7 +14,7 @@ IAM_DATA_FILE_NAME = "iam_data.json"
 ERASE_LINE = '\x1b[2K'
 
 
-def get_iam_data_file(account_id=None):
+def get_iam_data_file(account_id: str):
     parent = f"./aircache/{account_id}"
     pathlib.Path(parent).mkdir(parents=True, exist_ok=True)
     p = f"{parent}/{IAM_DATA_FILE_NAME}"

--- a/airiam/find_unused/RuntimeIamScanner.py
+++ b/airiam/find_unused/RuntimeIamScanner.py
@@ -15,13 +15,10 @@ ERASE_LINE = '\x1b[2K'
 
 
 def get_iam_data_file(account_id=None):
-    if account_id is None:
-        return IAM_DATA_FILE_NAME
-    else:
-        parent = f"./aircache/{account_id}"
-        pathlib.Path(parent).mkdir(parents=True, exist_ok=True)
-        p = f"{parent}/{IAM_DATA_FILE_NAME}"
-        return p
+    parent = f"./aircache/{account_id}"
+    pathlib.Path(parent).mkdir(parents=True, exist_ok=True)
+    p = f"{parent}/{IAM_DATA_FILE_NAME}"
+    return p
 
 
 class RuntimeIamScanner:


### PR DESCRIPTION
This pull request allows iam data to be caches per profile using account_id. 

It creates a folder **aircache** in which has folders named as the profile's account_id which contiain iam_data.json for the profile.